### PR TITLE
Provided arguments to RootViewModel initialize method.

### DIFF
--- a/lib/view/viewmodel/DetailViewModel.dart
+++ b/lib/view/viewmodel/DetailViewModel.dart
@@ -20,13 +20,11 @@ class DetailViewModel extends RootViewModel {
   DetailViewModel(this._repository);
 
   @override
-  initialize() {
-    // Nothing to do here
-  }
-
-  void onDetailIdFound(String id) {
-    _id = id;
-    _getPoiDetail(id);
+  initialize(dynamic arguments) {
+    if(arguments != null && arguments is String){
+      _id = arguments;
+      _getPoiDetail(_id);
+    }
   }
 
   void _getPoiDetail(String id) async {

--- a/lib/view/viewmodel/ListViewModel.dart
+++ b/lib/view/viewmodel/ListViewModel.dart
@@ -14,7 +14,7 @@ class ListViewModel extends RootViewModel {
   ListViewModel(this._repository, this._navigator);
 
   @override
-  initialize() {
+  initialize(dynamic arguments) {
     // Do nothing in that case
   }
 

--- a/lib/view/viewmodel/RootViewModel.dart
+++ b/lib/view/viewmodel/RootViewModel.dart
@@ -5,7 +5,7 @@ abstract class RootViewModel extends BaseViewModel {
 
   bool get loading => _loading;
 
-  initialize();
+  initialize(dynamic arguments);
 
   void showProgress() {
     _loading = true;

--- a/lib/view/widget/DetailWidget.dart
+++ b/lib/view/widget/DetailWidget.dart
@@ -11,7 +11,6 @@ class DetailWidget extends RootWidget<DetailViewModel> {
 
   @override
   Widget widget(DetailViewModel model) {
-    model.onDetailIdFound(Get.arguments);
     return Scaffold(
       body: Center(child: Text(model.poiTitle)),
     );

--- a/lib/view/widget/RootWidget.dart
+++ b/lib/view/widget/RootWidget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_architecture_template/view/viewmodel/RootViewModel.dart';
+import 'package:get/get.dart';
 import 'package:stacked/stacked.dart';
 
 abstract class RootWidget<T extends RootViewModel> extends StatelessWidget {
@@ -15,7 +16,7 @@ abstract class RootWidget<T extends RootViewModel> extends StatelessWidget {
         return widget(model);
       },
       viewModelBuilder: () => _model,
-      onModelReady: (model) => model.initialize(),
+      onModelReady: (model) => model.initialize(Get.arguments),
     );
   }
 


### PR DESCRIPTION
This change will provide the ViewModel with the arguments received by the Widget, so it can work with them as soon as the it's ready. 

Use case: 
- Detail screen receiving an id which needs to retrieve the details using that provided id.

It also fixes the following issue, caused by notifyListeners() being called before the widget was fully built.

![image](https://user-images.githubusercontent.com/19324743/108189806-74a0a580-7111-11eb-8592-0fbd6af669f3.png)

